### PR TITLE
Adds support for AVTransport:2, new ip method and readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Simple network player for DLNA/UPnP devices allows you discover devices and play
  
 ## TODO
 - [ ] Fix '&' bug
-- [ ] Set next media
+- [x] Set next media
 - [x] Volume control
 - [x] Position control
 - [ ] Add support to play media from local machine, e.g --play /home/username/media/music.mp3 for py3

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ __Commands:__
 ```--pause``` pause current playback  
 ```--stop``` stop current playback  
 ```--set-next <url>``` set the next media url to be played (gapless)
-```--next``` play the next media
+```--next``` play the next media  
 __Features:__  
 ```--all``` flag to discover all upnp devices, not only devices with AVTransport ability  
 ```--proxy``` use sync local download proxy, default is ip of current machine  

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Simple network player for DLNA/UPnP devices allows you discover devices and play
 - [x] Try it on Windows
 - [x] Add AVTransport:2 and further support
 - [ ] Play on multiple devices
-- [x] Integrate [local download proxy](https://github.com/cherezov/red)
+- [x] Integrate [local download proxy](#proxy)
 - [x] Stop/Pause playback
-- [x] Investigate if it possible to play images/video's on DLNA/UPnP powered TV (possible via [download proxy](https://github.com/cherezov/dlnap#proxy))
+- [x] Investigate if it is possible to play images/videos on DLNA/UPnP powered TV (possible via [download proxy](#proxy))
  
 ## Supported devices/software
  - [x] Yamaha RX577
- - [x] Samsung Smart TV (UE40ES5507) via [proxy](https://github.com/pedrocicoleme/dlnap#proxy)
+ - [x] Samsung Smart TV (UE40ES5507) via [proxy](#proxy)
  - [x] Marantz MR611
  - [x] [Kodi](https://kodi.tv/)
  - [ ] [Volumio2](https://github.com/volumio/Volumio2) (?)
- - [x] Pioneer MRX-3 via [proxy](https://github.com/pedrocicoleme/dlnap#proxy) and timeout >= 2
+ - [x] Pioneer MRX-3 via [proxy](#proxy) and timeout >= 2
  * _please email me if it works or doesn't work with your device_
 
 ## Prepare
@@ -45,6 +45,8 @@ __Commands:__
 ```--play <url>``` set current url for play and start playback it. In case of empty url - continue playing recent media  
 ```--pause``` pause current playback  
 ```--stop``` stop current playback  
+```--set-next <url>``` set the next media url to be played (gapless)
+```--next``` play the next media
 __Features:__  
 ```--all``` flag to discover all upnp devices, not only devices with AVTransport ability  
 ```--proxy``` use sync local download proxy, default is ip of current machine  

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simple network player for DLNA/UPnP devices allows you discover devices and play
  - [x] Marantz MR611
  - [x] [Kodi](https://kodi.tv/)
  - [ ] [Volumio2](https://github.com/volumio/Volumio2) (?)
- - [x] Pioneer MRX-3 via [proxy](https://github.com/pedrocicoleme/dlnap#proxy)
+ - [x] Pioneer MRX-3 via [proxy](https://github.com/pedrocicoleme/dlnap#proxy) and timeout >= 2
  * _please email me if it works or doesn't work with your device_
 
 ## Prepare

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Simple network player for DLNA/UPnP devices allows you discover devices and play
 - [x] Position control
 - [ ] Add support to play media from local machine, e.g --play /home/username/media/music.mp3 for py3
 - [x] Try it on Windows
-- [ ] Add AVTransport:2 and further support
+- [x] Add AVTransport:2 and further support
 - [ ] Play on multiple devices
 - [x] Integrate [local download proxy](https://github.com/cherezov/red)
 - [x] Stop/Pause playback
@@ -21,10 +21,11 @@ Simple network player for DLNA/UPnP devices allows you discover devices and play
  
 ## Supported devices/software
  - [x] Yamaha RX577
- - [x] Samsung Smart TV (UE40ES5507) via [proxy](https://github.com/cherezov/dlnap#proxy)
+ - [x] Samsung Smart TV (UE40ES5507) via [proxy](https://github.com/pedrocicoleme/dlnap#proxy)
  - [x] Marantz MR611
  - [x] [Kodi](https://kodi.tv/)
  - [ ] [Volumio2](https://github.com/volumio/Volumio2) (?)
+ - [x] Pioneer MRX-3 via [proxy](https://github.com/pedrocicoleme/dlnap#proxy)
  * _please email me if it works or doesn't work with your device_
 
 ## Prepare

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ __Commands:__
 ```--play <url>``` set current url for play and start playback it. In case of empty url - continue playing recent media  
 ```--pause``` pause current playback  
 ```--stop``` stop current playback  
-```--set-next <url>``` set the next media url to be played (gapless)
+```--set-next <url>``` set the next media url to be played (gapless)  
 ```--next``` play the next media  
 __Features:__  
 ```--all``` flag to discover all upnp devices, not only devices with AVTransport ability  

--- a/dlnap/dlnap.py
+++ b/dlnap/dlnap.py
@@ -881,7 +881,6 @@ if __name__ == '__main__':
         sys.exit(0)
 
     d = allDevices[0]
-    print(d)
 
     if url.lower().replace('https://', '').replace('www.',
                                                    '').startswith('youtube.'):

--- a/dlnap/dlnap.py
+++ b/dlnap/dlnap.py
@@ -163,7 +163,31 @@ def _get_port(location):
     return -- port number
     """
     port = re.findall('http://.*?:(\d+).*', location)
+
     return int(port[0]) if port else 80
+
+
+def _get_primary_ip():
+    """ Return the primary ip of the machine
+
+    by Jamieson Becker at StackOverflow
+    https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib#28950776
+
+    return -- the machine ip
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    try:
+        # doesn't even have to be reachable
+        s.connect(('10.255.255.255', 1))
+
+        ip = s.getsockname()[0]
+    except:
+        ip = '127.0.0.1'
+    finally:
+        s.close()
+
+    return ip
 
 
 def _get_control_urls(xml):
@@ -870,7 +894,8 @@ if __name__ == '__main__':
         proxy = True
 
     if proxy:
-        ip = socket.gethostbyname(socket.gethostname())
+        ip = _get_primary_ip()
+
         t = threading.Thread(
             target=runProxy, kwargs={'ip': ip,
                                      'port': proxy_port})


### PR DESCRIPTION
Hi,

this pull request adds support for avtransport:2 (I'm not really sure about the solution as I'm not well versed on the protocol, but seemed correct at first), introduces a new method to acquire the host ip (for distros as debian the ip returned by the old method was 127.0.0.1, which does not work for the proxy server) and fixes some information on the readme, reflecting the changes.